### PR TITLE
changes_autocmd fix

### DIFF
--- a/autoload/changes.vim
+++ b/autoload/changes.vim
@@ -79,7 +79,7 @@ fu! changes#Output(force)"{{{1
     endif
 endfu
 
-fu! s:Init()"{{{1
+fu! changes#Init()"{{{1
     " Message queue, that will be displayed.
     let s:msg      = []
     " Only check the first time this file is loaded
@@ -202,7 +202,7 @@ fu! changes#GetDiff(arg)"{{{1
     " a:arg == 2 Show Overview Window
     " a:arg == 3 Stay in diff mode
     try
-	call s:Init()
+	call changes#Init()
     catch /^changes:/
 	let s:verbose = 0
 	call s:WarningMsg()


### PR DESCRIPTION
Dear chrisbra,

I'm a noob regarding vim scripting. I've found that my alteration fixes the changes_autocmd option (it exited with E117: Unknown function: changes#Init error message). If it is correct please apply it to the plugin. If not, please let me know and i'll do a better job.

Best regards,
Mate
