### PR TITLE
filereadable check in GetDiffs

### DIFF
--- a/autoload/changes.vim
+++ b/autoload/changes.vim
@@ -209,6 +209,13 @@ fu! changes#GetDiff(arg)"{{{1
 	return
     endtry
 
+    if !filereadable(bufname(''))
+	call add(s:msg,"You've opened a new file so viewing changes is disabled until the file is saved (You have to reenable it if not using autocmd).")
+	let s:verbose = 0
+	call s:WarningMsg()
+	return
+    endif
+
     " Does not make sense to check an empty buffer
     if empty(bufname(''))
 	call add(s:msg,"The buffer does not contain a name. Check aborted!")


### PR DESCRIPTION
Dear chrisbra,

i've put a filereadable check in GetDiffs. It's useful if the plugin is enabled on a not yet saved new file and/or the plugin is enabled with autocmd through vimrc. At least i had some nasty error messages if i tried to enable it on a new, not saved file (and i'm loading this plugin through vimrc so it happens quite a few times). With this small addition vim displays a notice to the user and no exceptions happens.

Best regards,
Mate
