### PR TITLE
Allow changesPlugin to run in Neovim

### DIFF
--- a/plugin/changesPlugin.vim
+++ b/plugin/changesPlugin.vim
@@ -15,7 +15,7 @@ endif
 let g:loaded_changes       = 1
 let s:keepcpo              = &cpo
 set cpo&vim
-if v:version < 800
+if v:version < 800 && !has('nvim')
     echohl WarningMsg
     echomsg "The ChangesPlugin needs at least a Vim version 8"
     echohl Normal


### PR DESCRIPTION
The version check made when starting changesPlugin does not
detect Neovim which has async support that changesPlugin
requires.

Update the version check to account for Neovim to allow it to
start.